### PR TITLE
Update requests-responses.md

### DIFF
--- a/requests-responses.md
+++ b/requests-responses.md
@@ -326,7 +326,8 @@ Message structure:
 Wallet replies with **SendTransactionResponse**:
 
 ```tsx
-type SendTransactionResponse = SendTransactionResponseSuccess | SendTransactionResponseError; 
+type SendTransactionMessageResponse = SendTransactionResponseSuccess | SendTransactionResponseError; 
+type SendTransactionResponse = SendTransactionMessageResponse | SendTransactionMessageResponse[];
 
 interface SendTransactionResponseSuccess {
     result: <boc>;


### PR DESCRIPTION
DApp has to know not only the common result for all messages in a transaction, but also an intermediate result of all messages runs. For example, what if an one from 4 messages won't be sent by an internal error (for example due to `validUntil` parameter), then better to return results per messages to the DApp, which can resend only this one not performed message.