### PR TITLE
feat: add `network` and `from` fields to SignData params

### DIFF
--- a/requests-responses.md
+++ b/requests-responses.md
@@ -415,29 +415,29 @@ _Params_:
 
 ```json5
 {
-  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
-  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
   "type": "text",
-  "text": "Confirm new 2fa number:\n+1 234 567 8901"
+  "text": "Confirm new 2fa number:\n+1 234 567 8901",
+  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f"
 }
 ```
 
 ```json5
 {
-  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
-  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
   "type": "binary",
-  "bytes": "1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A=="
+  "bytes": "1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A==",
+  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f"
 }
 ```
 
 ```json5
 {
-  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
-  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
   "type": "cell",
   "schema": "transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;",
-  "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI="
+  "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI=",
+  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f"
 }
 ```
 
@@ -446,7 +446,7 @@ _Requests_:
 ```json5
 {
   "method": "signData",
-  "params": ["{\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"type\": \"text\",\"text\": \"Confirm new 2fa number:\\n+1 234 567 8901\"}"],
+  "params": ["{\"type\": \"text\",\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"text\": \"Confirm new 2fa number:\\n+1 234 567 8901\"}"],
   "id": "1"
 }
 ```
@@ -454,7 +454,7 @@ _Requests_:
 ```json5
 {
   "method": "signData",
-  "params": ["{\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"type\": \"binary\",\"bytes\": \"1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A==\"}"],
+  "params": ["{\"type\": \"binary\",\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"bytes\": \"1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A==\"}"],
   "id": "2"
 }
 ```
@@ -462,7 +462,7 @@ _Requests_:
 ```json5
 {
   "method": "signData",
-  "params": ["{\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"type\": \"cell\",\"schema\": \"transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;\",\"cell\": \"te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI=\"}"],
+  "params": ["{\"type\": \"cell\",\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"schema\": \"transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;\",\"cell\": \"te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI=\"}"],
   "id": "3"
 }
 ```

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -392,19 +392,19 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 - **Text**. JSON object with following properties:
   - **type** (string): 'text'
   - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
-  - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in raw format, optional): The signer address from which DApp intends to sign data. If not set, wallet allows user to select the signer's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the signer's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
   - **text** (string): arbitrary UTF-8 text to sign.
   
 - **Binary**. JSON object with following properties:
   - **type** (string): 'binary'
   - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
-  - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in raw format, optional): The signer address from which DApp intends to sign data. If not set, wallet allows user to select the signer's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the signer's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
   - **bytes** (string): base64 (not url safe) encoded arbitrary bytes array to sign.
 
 - **Cell**. JSON object with following properties:
   - **type** (string): 'cell'
   - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
-  - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in raw format, optional): The signer address from which DApp intends to sign data. If not set, wallet allows user to select the signer's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the signer's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
   - **schema** (string): TL-B schema of the cell payload as an UTF-8 string.  
   *If the schema contains several type definitions, the **last** declared type is treated as the root during serialization and deserialization.*
   - **cell** (string): base64 (not url safe) encoded BoC (single-root) with arbitrary cell to sign.

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -386,28 +386,28 @@ interface SignDataRequest {
 	id: string;
 }
 ```
+Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 
-Where `<sign-data-payload>` is a JSON object consisting of:
-
-- **Base Fields** (applies to all payload types):
+- **Text**. JSON object with following properties:
+  - **type** (string): 'text'
   - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
-  - **from** (string in <wc>:<hex> format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **text** (string): arbitrary UTF-8 text to sign.
+  
+- **Binary**. JSON object with following properties:
+  - **type** (string): 'binary'
+  - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **bytes** (string): base64 (not url safe) encoded arbitrary bytes array to sign.
 
-- **One of the 3 types of payload**:
-  - **Text**. JSON object with following properties:
-    - **type** (string): 'text'
-    - **text** (string): arbitrary UTF-8 text to sign. 
-
-  - **Binary**. JSON object with following properties:
-    - **type** (string): 'binary'
-    - **bytes** (string): base64 (not url safe) encoded arbitrary bytes array to sign.
-
-  - **Cell**. JSON object with following properties:
-    - **type** (string): 'cell'
-    - **schema** (string): TL-B schema of the cell payload as an UTF-8 string.  
+- **Cell**. JSON object with following properties:
+  - **type** (string): 'cell'
+  - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **schema** (string): TL-B schema of the cell payload as an UTF-8 string.  
     *If the schema contains several type definitions, the **last** declared type is treated as the root during serialization and deserialization.*
-    - **cell** (string): base64 (not url safe) encoded BoC (single-root) with arbitrary cell to sign.
-
+  - **cell** (string): base64 (not url safe) encoded BoC (single-root) with arbitrary cell to sign.
+  
 **Examples:**
 
 ```json5

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -411,8 +411,6 @@ Where `<sign-data-payload>` is JSON string with one of the 3 types of payload:
 
 **Examples:**
 
-_Params_:
-
 ```json5
 {
   "type": "text",
@@ -438,32 +436,6 @@ _Params_:
   "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI=",
   "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
   "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f"
-}
-```
-
-_Requests_:
-
-```json5
-{
-  "method": "signData",
-  "params": ["{\"type\": \"text\",\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"text\": \"Confirm new 2fa number:\\n+1 234 567 8901\"}"],
-  "id": "1"
-}
-```
-
-```json5
-{
-  "method": "signData",
-  "params": ["{\"type\": \"binary\",\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"bytes\": \"1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A==\"}"],
-  "id": "2"
-}
-```
-
-```json5
-{
-  "method": "signData",
-  "params": ["{\"type\": \"cell\",\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"schema\": \"transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;\",\"cell\": \"te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI=\"}"],
-  "id": "3"
 }
 ```
 

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -386,6 +386,7 @@ interface SignDataRequest {
 	id: string;
 }
 ```
+
 Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 
 - **Text**. JSON object with following properties:
@@ -405,9 +406,9 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
   - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
   - **from** (string in raw format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
   - **schema** (string): TL-B schema of the cell payload as an UTF-8 string.  
-    *If the schema contains several type definitions, the **last** declared type is treated as the root during serialization and deserialization.*
+  *If the schema contains several type definitions, the **last** declared type is treated as the root during serialization and deserialization.*
   - **cell** (string): base64 (not url safe) encoded BoC (single-root) with arbitrary cell to sign.
-  
+
 **Examples:**
 
 ```json5

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -387,21 +387,26 @@ interface SignDataRequest {
 }
 ```
 
-Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
+Where `<sign-data-payload>` is a JSON object consisting of:
 
-- **Text**. JSON object with following properties:
-  - **type** (string): 'text'
-  - **text** (string): arbitrary UTF-8 text to sign. 
+- **Base Fields** (applies to all payload types):
+  - **network** (NETWORK, optional): The network (mainnet or testnet) where DApp intends to sign data. If not set, the data is signed with the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
+  - **from** (string in <wc>:<hex> format, optional): The sender address from which DApp intends to sign data. If not set, wallet allows user to select the sender's address at the moment of signing data. If `from` parameter is set, the wallet should DO NOT ALLOW user to select the sender's address; If signing from the specified address is impossible, the wallet should show an alert and DO NOT ALLOW TO SIGN data.
 
-- **Binary**. JSON object with following properties:
-  - **type** (string): 'binary'
-  - **bytes** (string): base64 (not url safe) encoded arbitrary bytes array to sign.
+- **One of the 3 types of payload**:
+  - **Text**. JSON object with following properties:
+    - **type** (string): 'text'
+    - **text** (string): arbitrary UTF-8 text to sign. 
 
-- **Cell**. JSON object with following properties:
-  - **type** (string): 'cell'
-  - **schema** (string): TL-B schema of the cell payload as an UTF-8 string.  
-  *If the schema contains several type definitions, the **last** declared type is treated as the root during serialization and deserialization.*
-  - **cell** (string): base64 (not url safe) encoded BoC (single-root) with arbitrary cell to sign.
+  - **Binary**. JSON object with following properties:
+    - **type** (string): 'binary'
+    - **bytes** (string): base64 (not url safe) encoded arbitrary bytes array to sign.
+
+  - **Cell**. JSON object with following properties:
+    - **type** (string): 'cell'
+    - **schema** (string): TL-B schema of the cell payload as an UTF-8 string.  
+    *If the schema contains several type definitions, the **last** declared type is treated as the root during serialization and deserialization.*
+    - **cell** (string): base64 (not url safe) encoded BoC (single-root) with arbitrary cell to sign.
 
 **Examples:**
 
@@ -409,6 +414,8 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 {
   "method": "signData",
   "params": {
+    "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+    "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
     "type": "text",
     "text": "Confirm new 2fa number:\n+1 234 567 8901"
   },
@@ -420,6 +427,8 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 {
   "method": "signData",
   "params": {
+    "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+    "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
     "type": "binary",
     "bytes": "1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A=="
   },
@@ -431,6 +440,8 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 {
   "method": "signData",
   "params": {
+    "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+    "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
     "type": "cell",
     "schema": "transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;",
     "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI="

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -298,7 +298,7 @@ interface SendTransactionRequest {
 }
 ```
 
-Where `<transaction-payload>` is JSON with following properties:
+Where `<transaction-payload>` is JSON string with following properties:
 
 * `valid_until` (integer, optional): unix timestamp. after th moment transaction will be invalid.
 * `network` (NETWORK, optional): The network (mainnet or testnet) where DApp intends to send the transaction. If not set, the transaction is sent to the network currently set in the wallet, but this is not safe and DApp should always strive to set the network. If the `network` parameter is set, but the wallet has a different network set, the wallet should show an alert and DO NOT ALLOW TO SEND this transaction.
@@ -387,7 +387,7 @@ interface SignDataRequest {
 }
 ```
 
-Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
+Where `<sign-data-payload>` is JSON string with one of the 3 types of payload:
 
 - **Text**. JSON object with following properties:
   - **type** (string): 'text'
@@ -414,12 +414,12 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 ```json5
 {
   "method": "signData",
-  "params": {
+  "params": [{
     "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
     "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
     "type": "text",
     "text": "Confirm new 2fa number:\n+1 234 567 8901"
-  },
+  }],
   "id": "1"
 }
 ```
@@ -427,12 +427,11 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 ```json5
 {
   "method": "signData",
-  "params": {
-    "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "params": [{
     "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
     "type": "binary",
     "bytes": "1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A=="
-  },
+  }],
   "id": "2"
 }
 ```
@@ -440,13 +439,13 @@ Where `<sign-data-payload>` is JSON with one of the 3 types of payload:
 ```json5
 {
   "method": "signData",
-  "params": {
+  "params": [{
     "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
     "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
     "type": "cell",
     "schema": "transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;",
     "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI="
-  },
+  }],
   "id": "3"
 }
 ```

--- a/requests-responses.md
+++ b/requests-responses.md
@@ -411,15 +411,42 @@ Where `<sign-data-payload>` is JSON string with one of the 3 types of payload:
 
 **Examples:**
 
+_Params_:
+
+```json5
+{
+  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
+  "type": "text",
+  "text": "Confirm new 2fa number:\n+1 234 567 8901"
+}
+```
+
+```json5
+{
+  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
+  "type": "binary",
+  "bytes": "1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A=="
+}
+```
+
+```json5
+{
+  "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
+  "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
+  "type": "cell",
+  "schema": "transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;",
+  "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI="
+}
+```
+
+_Requests_:
+
 ```json5
 {
   "method": "signData",
-  "params": [{
-    "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
-    "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
-    "type": "text",
-    "text": "Confirm new 2fa number:\n+1 234 567 8901"
-  }],
+  "params": ["{\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"type\": \"text\",\"text\": \"Confirm new 2fa number:\\n+1 234 567 8901\"}"],
   "id": "1"
 }
 ```
@@ -427,11 +454,7 @@ Where `<sign-data-payload>` is JSON string with one of the 3 types of payload:
 ```json5
 {
   "method": "signData",
-  "params": [{
-    "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
-    "type": "binary",
-    "bytes": "1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A=="
-  }],
+  "params": ["{\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"type\": \"binary\",\"bytes\": \"1Z/SGh+3HFMKlVHSkN91DpcCzT4C5jzHT3sA/24C5A==\"}"],
   "id": "2"
 }
 ```
@@ -439,13 +462,7 @@ Where `<sign-data-payload>` is JSON string with one of the 3 types of payload:
 ```json5
 {
   "method": "signData",
-  "params": [{
-    "network": "-239", // enum NETWORK { MAINNET = '-239', TESTNET = '-3'}
-    "from": "0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f",
-    "type": "cell",
-    "schema": "transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;",
-    "cell": "te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI="
-  }],
+  "params": ["{\"network\": \"-239\",\"from\": \"0:348bcf827469c5fc38541c77fdd91d4e347eac200f6f2d9fd62dc08885f0415f\",\"type\": \"cell\",\"schema\": \"transfer#0f8a7ea5 query_id:uint64 amount:(VarUInteger 16) destination:MsgAddress response_destination:MsgAddress custom_payload:(Maybe ^Cell) forward_ton_amount:(VarUInteger 16) forward_payload:(Either Cell ^Cell) = InternalMsgBody;\",\"cell\": \"te6ccgEBAQEAVwAAqg+KfqVUbeTvKqB4h0AcnDgIAZucsOi6TLrfP6FcuPKEeTI6oB3fF/NBjyqtdov/KtutACCLqvfmyV9kH+Pyo5lcsrJzJDzjBJK6fd+ZnbFQe4+XggI=\"}"],
   "id": "3"
 }
 ```


### PR DESCRIPTION
Add missing `network` and `from` fields in to SignData params